### PR TITLE
Implement C-style printf specifiers and BeaconFormat API suite

### DIFF
--- a/src/coff/coff_windows.go
+++ b/src/coff/coff_windows.go
@@ -86,17 +86,19 @@ func resolveExternalAddress(symbolName string, outChannel chan<- interface{}) ui
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'R', 'e', 'm', 'o', 'v', 'e', 'V', 'a', 'l', 'u', 'e'}):
 				return windows.NewCallback(lighthouse.RemoveValue)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'A', 'l', 'l', 'o', 'c'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatAlloc)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'R', 'e', 's', 'e', 't'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatReset)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'F', 'r', 'e', 'e'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatFree)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'A', 'p', 'p', 'e', 'n', 'd'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatAppend)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'P', 'r', 'i', 'n', 't', 'f'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatPrintf)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'T', 'o', 'S', 't', 'r', 'i', 'n', 'g'}):
-				fallthrough
+				return windows.NewCallback(lighthouse.BeaconFormatToString)
+			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'I', 'n', 't'}):
+				return windows.NewCallback(lighthouse.BeaconFormatInt)
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'U', 's', 'e', 'T', 'o', 'k', 'e', 'n'}):
 				fallthrough
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'R', 'e', 'v', 'e', 'r', 't', 'T', 'o', 'k', 'e', 'n'}):
@@ -116,8 +118,6 @@ func resolveExternalAddress(symbolName string, outChannel chan<- interface{}) ui
 			case string([]rune{'t', 'o', 'W', 'i', 'd', 'e', 'C', 'h', 'a', 'r'}):
 				fallthrough
 			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'G', 'e', 't', 'O', 'u', 't', 'p', 'u', 't', 'D', 'a', 't', 'a'}):
-				fallthrough
-			case string([]rune{'B', 'e', 'a', 'c', 'o', 'n', 'F', 'o', 'r', 'm', 'a', 't', 'I', 'n', 't'}):
 				fallthrough
 			default:
 				// TODO: Check directives here for libraries

--- a/src/lighthouse/lighthouse_windows.go
+++ b/src/lighthouse/lighthouse_windows.go
@@ -13,12 +13,15 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/praetorian-inc/goffloader/src/memory"
-	"golang.org/x/sys/windows"
+	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf16"
 	"unsafe"
+
+	"github.com/praetorian-inc/goffloader/src/memory"
+	"golang.org/x/sys/windows"
 )
 
 func GetCoffOutputForChannel(channel chan<- interface{}) func(int, uintptr, int) uintptr {
@@ -33,54 +36,209 @@ func GetCoffOutputForChannel(channel chan<- interface{}) func(int, uintptr, int)
 	}
 }
 
-func GetCoffPrintfForChannel(channel chan<- interface{}) func(int, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr) uintptr {
-	return func(beaconType int, data uintptr, arg0 uintptr, arg1 uintptr, arg2 uintptr, arg3 uintptr, arg4 uintptr, arg5 uintptr, arg6 uintptr, arg7 uintptr, arg8 uintptr, arg9 uintptr) uintptr {
-		var out string
-		out = memory.ReadCStringFromPtr(data)
-		numArgs := strings.Count(out, "%")
-		args := []uintptr{arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}
+type formatBuffer struct {
+	original uintptr
+	buffer   uintptr
+	length   int32
+	size     int32
+}
 
-		fString := ""
-		argOffset := 0
-		skipChar := false
-		for i := range len(out) {
-			c := out[i]
+var (
+	formatBuffers   = make(map[uintptr][]byte)
+	formatBuffersMu sync.Mutex
+)
 
-			if skipChar {
-				skipChar = false
-				continue
+func isLikelyWideString(ptr uintptr) bool {
+	if ptr == 0 {
+		return false
+	}
+	sample := memory.ReadBytesFromPtr(ptr, 8)
+	if len(sample) < 2 {
+		return false
+	}
+	zeros := 0
+	nonZeros := 0
+	for i := 0; i+1 < len(sample); i += 2 {
+		if sample[i] == 0 && sample[i+1] == 0 {
+			break
+		}
+		if sample[i+1] == 0 {
+			zeros++
+		} else {
+			nonZeros++
+		}
+	}
+	return zeros > 0 && nonZeros == 0
+}
+
+func readCString(ptr uintptr, preferWide bool) string {
+	if ptr == 0 {
+		return ""
+	}
+	if preferWide || isLikelyWideString(ptr) {
+		return memory.ReadWStringFromPtr(ptr)
+	}
+	return memory.ReadCStringFromPtr(ptr)
+}
+
+func formatPrintf(format string, args []uintptr) string {
+	var builder strings.Builder
+	argIndex := 0
+	i := 0
+	for i < len(format) {
+		if format[i] != '%' {
+			builder.WriteByte(format[i])
+			i++
+			continue
+		}
+		if i+1 < len(format) && format[i+1] == '%' {
+			builder.WriteByte('%')
+			i += 2
+			continue
+		}
+
+		start := i
+		i++
+
+		flags := ""
+		for i < len(format) && strings.ContainsRune("+-#0 ", rune(format[i])) {
+			flags += string(format[i])
+			i++
+		}
+
+		width := ""
+		widthFromArg := false
+		widthValue := 0
+		if i < len(format) && format[i] == '*' {
+			widthFromArg = true
+			if argIndex < len(args) {
+				widthValue = int(args[argIndex])
+				argIndex++
 			}
-
-			if argOffset > numArgs {
-				fString += string(c)
-				continue
-			}
-
-			if c == '%' && i < len(out)-1 {
-				d := out[i+1]
-				switch d {
-				case 's':
-					s := memory.ReadCStringFromPtr(args[argOffset])
-					// no way to tell if the string is unicode or ansi formatted, so assume if we read
-					// more than 4 characters without a null byte that it's ANSI
-					if len(s) < 5 {
-						s = memory.ReadWStringFromPtr(args[argOffset])
-					}
-					fString += s
-				case 'p':
-					fString += fmt.Sprintf("%x", unsafe.Pointer(args[argOffset]))
-				default:
-					fString += fmt.Sprintf("%"+string(d), args[argOffset])
-				}
-				argOffset++
-				skipChar = true
-			} else {
-				fString += string(c)
+			i++
+		} else {
+			for i < len(format) && format[i] >= '0' && format[i] <= '9' {
+				width += string(format[i])
+				i++
 			}
 		}
 
-		//fmt.Printf("%s\n", fString) //uncomment for debugging failed BOF/Executable runs
-		channel <- fString
+		precision := ""
+		precisionFromArg := false
+		precisionValue := 0
+		if i < len(format) && format[i] == '.' {
+			precision = "."
+			i++
+			if i < len(format) && format[i] == '*' {
+				precisionFromArg = true
+				if argIndex < len(args) {
+					precisionValue = int(args[argIndex])
+					argIndex++
+				}
+				i++
+			} else {
+				for i < len(format) && format[i] >= '0' && format[i] <= '9' {
+					precision += string(format[i])
+					i++
+				}
+			}
+		}
+
+		length := ""
+		switch {
+		case i+2 < len(format) && format[i:i+3] == "I64":
+			length = "I64"
+			i += 3
+		case i+1 < len(format) && format[i:i+2] == "ll":
+			length = "ll"
+			i += 2
+		case i+1 < len(format) && format[i:i+2] == "hh":
+			length = "hh"
+			i += 2
+		case i < len(format) && strings.ContainsRune("lhjztwL", rune(format[i])):
+			length = string(format[i])
+			i++
+		}
+
+		if i >= len(format) {
+			builder.WriteString(format[start:])
+			break
+		}
+
+		spec := format[i]
+		i++
+
+		if widthFromArg {
+			if widthValue < 0 {
+				if !strings.Contains(flags, "-") {
+					flags += "-"
+				}
+				widthValue = -widthValue
+			}
+			width = strconv.Itoa(widthValue)
+		}
+		if precisionFromArg {
+			if precisionValue >= 0 {
+				precision = "." + strconv.Itoa(precisionValue)
+			} else {
+				precision = ""
+			}
+		}
+
+		if argIndex >= len(args) {
+			builder.WriteString(format[start:i])
+			continue
+		}
+
+		switch spec {
+		case 's':
+			preferWide := length == "l" || length == "w" || length == "L"
+			value := readCString(args[argIndex], preferWide)
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"s", value))
+		case 'S':
+			value := readCString(args[argIndex], true)
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"s", value))
+		case 'c', 'C':
+			value := rune(args[argIndex])
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"c", value))
+		case 'p':
+			value := unsafe.Pointer(args[argIndex])
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"p", value))
+		case 'd', 'i':
+			value := int64(args[argIndex])
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"d", value))
+		case 'u':
+			value := uint64(args[argIndex])
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+"d", value))
+		case 'x', 'X', 'o':
+			value := uint64(args[argIndex])
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+string(spec), value))
+		case 'f', 'F', 'e', 'E', 'g', 'G':
+			value := math.Float64frombits(uint64(args[argIndex]))
+			argIndex++
+			builder.WriteString(fmt.Sprintf("%"+flags+width+precision+string(spec), value))
+		default:
+			builder.WriteString(format[start:i])
+		}
+	}
+
+	return builder.String()
+}
+
+func GetCoffPrintfForChannel(channel chan<- interface{}) func(int, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr, uintptr) uintptr {
+	return func(beaconType int, data uintptr, arg0 uintptr, arg1 uintptr, arg2 uintptr, arg3 uintptr, arg4 uintptr, arg5 uintptr, arg6 uintptr, arg7 uintptr, arg8 uintptr, arg9 uintptr) uintptr {
+		out := memory.ReadCStringFromPtr(data)
+		args := []uintptr{arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}
+		formatted := formatPrintf(out, args)
+		//fmt.Printf("%s\n", formatted) //uncomment for debugging failed BOF/Executable runs
+		channel <- formatted
 		return 0
 	}
 }
@@ -171,6 +329,152 @@ func RemoveValue(key uintptr) uintptr {
 		return uintptr(1)
 	}
 	return uintptr(0)
+}
+
+func swapEndianness(indata uint32) uint32 {
+	return (indata>>24)&0x000000ff |
+		(indata>>8)&0x0000ff00 |
+		(indata<<8)&0x00ff0000 |
+		(indata<<24)&0xff000000
+}
+
+func getFormatBuffer(format *formatBuffer) ([]byte, bool) {
+	if format == nil {
+		return nil, false
+	}
+	formatPtr := uintptr(unsafe.Pointer(format))
+	formatBuffersMu.Lock()
+	buf, ok := formatBuffers[formatPtr]
+	formatBuffersMu.Unlock()
+	return buf, ok
+}
+
+func appendToFormatBuffer(format *formatBuffer, data []byte) uintptr {
+	if format == nil {
+		return 0
+	}
+	buf, ok := getFormatBuffer(format)
+	if !ok {
+		return 0
+	}
+	if format.size <= 0 {
+		return 0
+	}
+	used := int(format.buffer - format.original)
+	if used < 0 || used > len(buf) {
+		return 0
+	}
+	if used+len(data) > len(buf) {
+		return 0
+	}
+	copy(buf[used:], data)
+	used += len(data)
+	format.buffer = format.original + uintptr(used)
+	format.length = int32(used)
+	return 1
+}
+
+func BeaconFormatAlloc(format *formatBuffer, maxsz int32) uintptr {
+	if format == nil || maxsz <= 0 {
+		return 0
+	}
+	buf := make([]byte, maxsz)
+	format.original = uintptr(unsafe.Pointer(&buf[0]))
+	format.buffer = format.original
+	format.length = 0
+	format.size = maxsz
+
+	formatPtr := uintptr(unsafe.Pointer(format))
+	formatBuffersMu.Lock()
+	formatBuffers[formatPtr] = buf
+	formatBuffersMu.Unlock()
+	return 1
+}
+
+func BeaconFormatReset(format *formatBuffer) uintptr {
+	if format == nil {
+		return 0
+	}
+	buf, ok := getFormatBuffer(format)
+	if !ok {
+		return 0
+	}
+	for i := range buf {
+		buf[i] = 0
+	}
+	format.buffer = format.original
+	format.length = 0
+	return 1
+}
+
+func BeaconFormatFree(format *formatBuffer) uintptr {
+	if format == nil {
+		return 0
+	}
+	formatPtr := uintptr(unsafe.Pointer(format))
+	formatBuffersMu.Lock()
+	delete(formatBuffers, formatPtr)
+	formatBuffersMu.Unlock()
+
+	format.original = 0
+	format.buffer = 0
+	format.length = 0
+	format.size = 0
+	return 1
+}
+
+func BeaconFormatAppend(format *formatBuffer, text uintptr, length int32) uintptr {
+	if format == nil || text == 0 || length <= 0 {
+		return 0
+	}
+	data := memory.ReadBytesFromPtr(text, uint32(length))
+	return appendToFormatBuffer(format, data)
+}
+
+func BeaconFormatPrintf(format *formatBuffer, fmtPtr uintptr, arg0 uintptr, arg1 uintptr, arg2 uintptr, arg3 uintptr, arg4 uintptr, arg5 uintptr, arg6 uintptr, arg7 uintptr, arg8 uintptr, arg9 uintptr) uintptr {
+	if format == nil || fmtPtr == 0 {
+		return 0
+	}
+	fmtString := memory.ReadCStringFromPtr(fmtPtr)
+	args := []uintptr{arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}
+	formatted := formatPrintf(fmtString, args)
+	return appendToFormatBuffer(format, []byte(formatted))
+}
+
+func BeaconFormatToString(format *formatBuffer, size *int32) uintptr {
+	if format == nil {
+		return 0
+	}
+	if size != nil {
+		*size = format.length
+	}
+	return format.original
+}
+
+func BeaconFormatInt(format *formatBuffer, value int32) uintptr {
+	if format == nil {
+		return 0
+	}
+	buf, ok := getFormatBuffer(format)
+	if !ok {
+		return 0
+	}
+	if format.size <= 0 {
+		return 0
+	}
+	used := int(format.buffer - format.original)
+	if used < 0 || used > len(buf) {
+		return 0
+	}
+	if used+4 > len(buf) {
+		return 0
+	}
+	swapped := swapEndianness(uint32(value))
+	binary.LittleEndian.PutUint32(buf[used:used+4], swapped)
+	used += 4
+	format.buffer = format.original + uintptr(used)
+	format.length = int32(used)
+	return 1
 }
 
 func PackArgs(data []string) ([]byte, error) {

--- a/src/memory/memory_windows.go
+++ b/src/memory/memory_windows.go
@@ -1,6 +1,9 @@
 package memory
 
-import "unsafe"
+import (
+	"unicode/utf16"
+	"unsafe"
+)
 
 func CopyMemory(dst, src uintptr, length uint32) {
 	copy((*[1 << 30]byte)(unsafe.Pointer(dst))[:length], (*[1 << 30]byte)(unsafe.Pointer(src))[:length])
@@ -41,16 +44,15 @@ func ReadWStringFromPtr(src uintptr) string {
 	if src == 0 {
 		return ""
 	}
-	str := ""
-	offset := 0
+	var codeUnits []uint16
+	offset := uintptr(0)
 	for {
-		c1 := *(*byte)(unsafe.Pointer(src + uintptr(offset)))
-		c2 := *(*byte)(unsafe.Pointer(src + uintptr(offset+1)))
-		if c1 == 0 && c2 == 0 {
+		c := *(*uint16)(unsafe.Pointer(src + offset))
+		if c == 0 {
 			break
 		}
-		str += string(c1) + string(c2)
+		codeUnits = append(codeUnits, c)
 		offset += 2
 	}
-	return str
+	return string(utf16.Decode(codeUnits))
 }


### PR DESCRIPTION
This PR significantly improves the compatibility and output quality of the Beacon API implementation. It addresses artifacting issues in `BeaconPrintf` output and implements the missing `BeaconFormat*` API suite, which is required by some modern BOFs (e.g., ChromeKatz).

#### Problem
The previous `BeaconPrintf` implementation used a primitive manual parser that only explicitly handled `%s` and `%p`, falling back to Go's default `fmt.Sprintf` for other specifiers. Since arguments are passed as `uintptr` values, specifiers like `%S` (wide strings) or `%i` (integers) would print the raw memory address (e.g., `%!S(uintptr=...)`) instead of the intended value.

Furthermore, the `BeaconFormat*` functions were stubs that fell through to default handlers, causing BOFs that rely on dynamic output buffering to fail or crash.

#### Changes
**1. Robust Printf Parsing (`formatPrintf`)**
Implemented a comprehensive C-style printf parser that supports:
- **Comprehensive Specifiers**: Support for `%s`, `%S`, `%c`, `%C`, `%p`, `%d`, `%i`, `%u`, `%x`, `%X`, `%o`, `%f`, etc.
- **Wide String Support**: Properly handles `%S` (and `%ls`/`%ws`) by utilizing a fixed `ReadWStringFromPtr` to decode UTF-16 code units.
- **Flags, Width, and Precision**: Supports standard C flags (`+`, `-`, `#`, `0`, space) and dynamic `*` width/precision.
- **Heuristic String Detection**: Added a heuristic to better distinguish between ANSI and UTF-16 strings when specifiers are ambiguous.

**2. BeaconFormat API Suite**
Fully implemented the dynamic buffer management suite:
- `BeaconFormatAlloc`: Allocates a managed buffer for output assembly.
- `BeaconFormatReset` & `BeaconFormatFree`: Proper lifecycle management for temporary buffers.
- `BeaconFormatAppend` & `BeaconFormatPrintf`: Methods to populate the buffer, with the latter utilizing the new robust printf logic.
- `BeaconFormatToString`: Retrieves the final assembled string pointer.
- `BeaconFormatInt`: Appends a 4-byte integer in the expected big-endian format.

**3. Memory Access Improvements**
- Modified `ReadWStringFromPtr` to correctly decode UTF-16 code units instead of raw byte concatenation, ensuring proper representation of multi-byte characters.

**4. COFF Symbol Resolution**
- Updated the COFF loader to resolve individual `BeaconFormat*` symbols to their new Go implementations.

#### Validation

**Case 1: [locale.x64.o](https://github.com/trustedsec/CS-Situational-Awareness-BOF/blob/master/src/SA/locale/entry.c) (Formatting Fix)**
This BOF uses `%S` extensively for locale information.

*Output Before:*
```text
Locale: %!S(uintptr=948722202866) (%!S(uintptr=948722202696))
LCID: dc00000409
Date: %!S(uintptr=948722203036)
Country: %!S(uintptr=948722203206)
```

*Output After:*
```text
Locale: English (en-US)
LCID: 5400000409
Date: Tuesday, January 20, 2026
Country: United States
```

**Case 2: [ChromeKatz](https://github.com/Meckazin/ChromeKatz) (Compatibility Fix)**
ChromeKatz utilizes `BeaconFormatPrintf` and `BeaconFormatToString` for its credential output.
- **Before**: Failed to run due to missing `BeaconFormat*` implementations.
- **After**: Functions correctly and returns the full set of captured credentials.