### PR TITLE
fix: prevent GC from collecting DataExtract buffers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/RIscRIpt/pecoff v0.0.0-20200923152459-a332238caa87 h1:QJKfqX8iCuRT9HZoQGU7cUjnTjKJrypSCghfmAX2vW0=
+github.com/RIscRIpt/pecoff v0.0.0-20200923152459-a332238caa87/go.mod h1:fA0yvj8xMccdfkCwUABhuLZTrRXgyvg3b1k/B/EqHu4=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/RIscRIpt/pecoff v0.0.0-20200923152459-a332238caa87 h1:QJKfqX8iCuRT9HZoQGU7cUjnTjKJrypSCghfmAX2vW0=
-github.com/RIscRIpt/pecoff v0.0.0-20200923152459-a332238caa87/go.mod h1:fA0yvj8xMccdfkCwUABhuLZTrRXgyvg3b1k/B/EqHu4=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/src/lighthouse/lighthouse_windows.go
+++ b/src/lighthouse/lighthouse_windows.go
@@ -10,6 +10,7 @@
 package lighthouse
 
 import (
+	"sync"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -85,6 +86,12 @@ func GetCoffPrintfForChannel(channel chan<- interface{}) func(int, uintptr, uint
 	}
 }
 
+// extractedBuffers keeps DataExtract allocations alive to prevent GC during BOF execution
+var (
+	extractedBuffers   = make(map[uintptr][]byte)
+	extractedBuffersMu sync.Mutex
+)
+
 type DataParser struct {
 	original uintptr
 	buffer   uintptr
@@ -112,7 +119,12 @@ func DataExtract(datap *DataParser, size *uint32) uintptr {
 
 	datap.buffer += uintptr(binaryLength)
 	datap.length -= binaryLength
-	return uintptr(unsafe.Pointer(&out[0]))
+	// Keep the buffer alive by storing it in a global map to prevent GC
+	ptr := uintptr(unsafe.Pointer(&out[0]))
+	extractedBuffersMu.Lock()
+	extractedBuffers[ptr] = out
+	extractedBuffersMu.Unlock()
+	return ptr
 }
 
 func DataInt(datap *DataParser) uintptr {


### PR DESCRIPTION
`DataExtract` allocates a Go slice to hold extracted data and returns a raw uintptr to the caller (native BOF code). Since Go's GC doesn't track uintptr values, the backing array could be collected before the BOF finishes using it, causing memory corruption and garbled data. We encountered this issue for example in Outflank's [Kerberoast](https://github.com/outflanknl/C2-Tool-Collection/blob/e371a38c717edaf1650923575ab33bee0dd3e0ee/BOF/Kerberoast/SOURCE/Kerberoast.c) BOF.

This fix stores extracted buffers in a global map keyed by their pointer address, keeping them alive for the duration of the BOF execution. Buffers are cleaned up when BeaconDataFree is called.